### PR TITLE
Storage domain change

### DIFF
--- a/lib/impl/AzureBlobFiles.js
+++ b/lib/impl/AzureBlobFiles.js
@@ -26,7 +26,7 @@ require('../types.jsdoc') // for VS Code autocomplete
 const STREAM_BLOCK_SIZE = 2 * 1024 * 1024
 const STREAM_MAX_BUFFERS = 20
 const AZURE_STORAGE_DOMAIN = 'blob.core.windows.net'
-const DEFAULT_CDN_STORAGE_HOST = 'files.adobeio-static.net'
+const DEFAULT_CDN_STORAGE_HOST = 'firefly.azureedge.net'
 
 /**
  * Creates a container if it does not exist

--- a/test/impl/AzureBlobFiles.test.js
+++ b/test/impl/AzureBlobFiles.test.js
@@ -23,7 +23,7 @@ const fakeSASCredentials = {
 }
 const fakeAborter = 'fakeAborter'
 
-const DEFAULT_CDN_STORAGE_HOST = 'https://files.adobeio-static.net'
+const DEFAULT_CDN_STORAGE_HOST = 'https://firefly.azureedge.net'
 
 beforeEach(async () => {
   expect.hasAssertions()


### PR DESCRIPTION
Change storage file domain from using `files.adobeio-static.net` to `firefly.azureedge.net`


## Description

Change required to avoid any issues due to redirection

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
unit test and manual tests
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
