### PR TITLE
Added check for token expiry for all file operations

### DIFF
--- a/lib/Files.js
+++ b/lib/Files.js
@@ -215,6 +215,19 @@ class Files {
   /* **************************** PRIVATE ABSTRACT METHODS TO IMPLEMENT ***************************** */
 
   /**
+   * [Internal] Re-initialize current instance with new Creds
+   *
+   * @param {AzureCredentials} credentials {@link AzureCredentials}
+   * @returns {void}
+   *
+   * @private
+   * @memberof Files
+   */
+  async _initWithNewCreds (credentials) {
+    throwNotImplemented('_initWithNewCreds')
+  }
+
+  /**
    * @param {RemotePathString} filePath {@link RemotePathString}
    * @returns {Promise<Array<RemoteFileProperties>>} resolves to array of {@link RemoteFileProperties}
    *
@@ -410,6 +423,8 @@ class Files {
   async list (filePath = '') {
     validateFilePath(filePath, { filePath })
     filePath = Files._normalizeRemotePath(filePath)
+    // refresh token if expired
+    await this._initWithNewCreds()
     if (Files._isRemoteDirectory(filePath)) {
       logger.debug(`listing files in folder '${filePath}'`)
       return this._listFolder(filePath)
@@ -483,6 +498,8 @@ class Files {
     options.position = options.position || 0
 
     logger.debug(`creating read stream for file '${filePath}' at position ${options.position} and length ${options.length}`)
+    // refresh token if expired
+    await this._initWithNewCreds()
     return this._createReadStream(filePath, options)
   }
 
@@ -508,6 +525,8 @@ class Files {
     Files._throwIfRemoteDirectory(filePath, details)
 
     logger.debug(`creating write stream for file '${filePath}'`)
+    // refresh token if expired
+    await this._initWithNewCreds()
     return this._createWriteStream(filePath)
   }
 
@@ -558,6 +577,9 @@ class Files {
     filePath = Files._normalizeRemotePath(filePath)
     Files._throwIfRemoteDirectory(filePath, details)
 
+    // refresh token if expired
+    await this._initWithNewCreds()
+
     if (content instanceof stream.Readable) {
       logger.debug(`writing a read stream to '${filePath}'`)
       return this._writeStream(filePath, content)
@@ -583,6 +605,9 @@ class Files {
     filePath = Files._normalizeRemotePath(filePath)
     logger.debug(`getting file properties for '${filePath}'`)
     // todo go fetch some other properties like exists, size, metadata...
+
+    // refresh token if expired
+    await this._initWithNewCreds()
     const fileInfo = await this.getFileInfo(filePath)
     return fileInfo
   }
@@ -642,6 +667,9 @@ class Files {
       }
       return Files._normalizeRemotePath(filePath)
     }
+    // refresh token if expired
+    await this._initWithNewCreds()
+
     const _getFiles = async (filePath, isLocal = false, localFileStats) => {
       if (isLocal) {
         if (!localFileStats) {
@@ -820,6 +848,8 @@ class Files {
     }).label('options').required(), options)
 
     logger.debug(`getting presign URL for file '${filePath}'`)
+    // refresh token if expired
+    await this._initWithNewCreds()
     return await this._getPresignUrl(filePath, options)
   }
 
@@ -832,6 +862,9 @@ class Files {
    */
   async revokeAllPresignURLs () {
     logger.debug('revoking presign URLs')
+
+    // refresh token if expired
+    await this._initWithNewCreds()
     return await this._revokeAllPresignURLs()
   }
 }

--- a/lib/impl/AzureBlobFiles.js
+++ b/lib/impl/AzureBlobFiles.js
@@ -99,12 +99,9 @@ class AzureBlobFiles extends Files {
     this.containerClientPublic = null
     /** @private */
     this.usesSASCreds = null
+
     if (credentials.sasURLPrivate) {
-      const azureCreds = new azure.AnonymousCredential()
-      const pipeline = azure.newPipeline(azureCreds)
-      this.containerClientPrivate = new azure.ContainerClient(credentials.sasURLPrivate, pipeline)
-      this.containerClientPublic = new azure.ContainerClient(credentials.sasURLPublic, pipeline)
-      /** @private */
+      this._initWithNewCreds(credentials)
       this.usesSASCreds = true
     } else {
       const azureCreds = new azure.StorageSharedKeyCredential(credentials.storageAccount, credentials.storageAccessKey)
@@ -182,6 +179,27 @@ class AzureBlobFiles extends Files {
     }
     azureProps.blockBlobClient = azureProps.containerClient.getBlockBlobClient(usePath)
     return azureProps
+  }
+
+  /**
+   * @memberof AzureBlobFiles
+   * @override
+   * @private
+   */
+  async _initWithNewCreds (creds) {
+    let credentials = creds
+    // get credentails if not passed
+    if (!credentials && !this.hasOwnCredentials) {
+      // use TVM Client to get credentials, this will refresh token if it was expired
+      credentials = await utils.wrapTVMRequest(this.tvm.getAzureBlobCredentials())
+    }
+
+    if (credentials || !this.hasOwnCredentials) {
+      const azureCreds = new azure.AnonymousCredential()
+      const pipeline = azure.newPipeline(azureCreds)
+      this.containerClientPrivate = new azure.ContainerClient(credentials.sasURLPrivate, pipeline)
+      this.containerClientPublic = new azure.ContainerClient(credentials.sasURLPublic, pipeline)
+    }
   }
 
   /** [Internal] Set empty access policy

--- a/test/Files.test.js
+++ b/test/Files.test.js
@@ -19,10 +19,6 @@ beforeEach(() => {
   initWithNewCredsMock.mockReset()
 })
 
-afterAll(() => {
-  initWithNewCredsMock.mockRestore()
-})
-
 describe('init', () => {
   test('missing implementation', async () => {
     await global.expectToThrowNotImplemented(Files.init.bind(Files), 'init')

--- a/test/impl/AzureBlobFiles.test.js
+++ b/test/impl/AzureBlobFiles.test.js
@@ -864,6 +864,33 @@ describe('_revokeAllPresignURLs', () => {
   })
 })
 
+describe('_initWithNewCreds', () => {
+  const tvm = jest.fn()
+  let files
+
+  beforeEach(async () => {
+    tvm.mockReset()
+    tvm.getAzureBlobCredentials = jest.fn()
+    tvm.getAzureBlobCredentials.mockResolvedValue(fakeSASCredentials)
+
+    files = await AzureBlobFiles.init(fakeSASCredentials, tvm)
+  })
+
+  test('_initWithNewCreds pass valid new creds', async () => {
+    await files._initWithNewCreds(fakeSASCredentials)
+    expect(tvm.getAzureBlobCredentials).not.toHaveBeenCalled()
+  })
+  test('_initWithNewCreds no creds hasOwnCredentials = false', async () => {
+    await files._initWithNewCreds()
+    expect(tvm.getAzureBlobCredentials).toHaveBeenCalled()
+  })
+  test('_initWithNewCreds no creds hasOwnCredentials = true', async () => {
+    files = await AzureBlobFiles.init(fakeUserCredentials)
+    await files._initWithNewCreds()
+    expect(tvm.getAzureBlobCredentials).not.toHaveBeenCalled()
+  })
+})
+
 describe('_statusFromProviderError', () => {
   /** @type {AzureBlobFiles} */
   let files


### PR DESCRIPTION
Related issue #7 
In case token is expired new token will be fetched using TVM client.
TVM Client check token expiry and if expired fetches new one from TVM.

All file operations will now check and refresh token before execution.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

unit tests, manual test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
