### PR TITLE
Fix BYO custom access policy flow

### DIFF
--- a/lib/FilesError.js
+++ b/lib/FilesError.js
@@ -48,6 +48,7 @@ E('ERROR_BAD_FILE_TYPE', '%s')
 E('ERROR_OUT_OF_RANGE', '%s')
 E('ERROR_MISSING_OPTION', '%s')
 E('ERROR_UNSUPPORTED_OPERATION', '%s')
+E('ERROR_INIT_FAILURE', '%s')
 
 module.exports = {
   codes,

--- a/lib/impl/AzureBlobFiles.js
+++ b/lib/impl/AzureBlobFiles.js
@@ -217,7 +217,7 @@ class AzureBlobFiles extends Files {
    * @private
    */
   async _setAccessPolicy () {
-    const id = uuidv4()
+    const id = 'aio-lib-files-' + uuidv4()
     // set access policy with new id and without any permissions
     await this.containerClientPrivate.setAccessPolicy(undefined, [{ id: id, accessPolicy: { permission: '' } }])
   }
@@ -249,7 +249,11 @@ class AzureBlobFiles extends Files {
     if (aclObj.elements) {
       const signedIdentifiers = aclObj.elements[0]
       if (signedIdentifiers.elements) {
+        if (signedIdentifiers.elements.length > 1) {
+          this._hasCustomAccessPolicies = true // flag to mark presense of custom policies
+        }
         const signedIdentifier = signedIdentifiers.elements[0].elements
+
         signedIdentifier.forEach(function (val, index, arr) {
           if (val.name === 'Id') {
             id = val.elements[0].text
@@ -278,10 +282,33 @@ class AzureBlobFiles extends Files {
    */
   async _addAccessPolicyIfNotExists () {
     const identifier = await this._getAccessPolicy()
-    logger.debug('found access policy with identifier ' + identifier)
-    if (!identifier) {
+    if (identifier) {
+      logger.debug('found access policy with identifier ' + identifier)
+      if (this.hasOwnCredentials) {
+        // check if identifier is custom or not
+        if (this._hasCustomAccessPolicies || this._isCustomPolicy(identifier)) {
+          const msg = 'Container has one or more custom policies defined. Either remove all custom policies or use another container.'
+          logAndThrow(new codes.ERROR_INIT_FAILURE({ messageValues: [msg], sdkDetails: {} }))
+        }
+      }
+    } else {
       logger.debug('adding default access policy')
       await this._setAccessPolicy()
+    }
+  }
+
+  /**
+   * [Internal] Check if identifier is custom or not
+   *
+   * @private
+   */
+  _isCustomPolicy (identifier) {
+    if (identifier.startsWith('aio-lib-files')) {
+      return false
+    } else {
+      // if its uuidv4 type of identifier then consider it as non custom, this is to support any already created policies by aio-lib-flies
+      const testUUIDv4 = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi
+      return !(testUUIDv4.test(identifier))
     }
   }
 

--- a/lib/impl/AzureBlobFiles.js
+++ b/lib/impl/AzureBlobFiles.js
@@ -217,7 +217,7 @@ class AzureBlobFiles extends Files {
    * @private
    */
   async _setAccessPolicy () {
-    const id = 'aio-lib-files-' + uuidv4()
+    const id = uuidv4()
     // set access policy with new id and without any permissions
     await this.containerClientPrivate.setAccessPolicy(undefined, [{ id: id, accessPolicy: { permission: '' } }])
   }
@@ -250,7 +250,8 @@ class AzureBlobFiles extends Files {
       const signedIdentifiers = aclObj.elements[0]
       if (signedIdentifiers.elements) {
         if (signedIdentifiers.elements.length > 1) {
-          this._hasCustomAccessPolicies = true // flag to mark presense of custom policies
+          const msg = 'Container has one or more custom policies defined. Either remove all custom policies or use another container.'
+          logAndThrow(new codes.ERROR_INIT_FAILURE({ messageValues: [msg], sdkDetails: {} }))
         }
         const signedIdentifier = signedIdentifiers.elements[0].elements
 
@@ -286,7 +287,7 @@ class AzureBlobFiles extends Files {
       logger.debug('found access policy with identifier ' + identifier)
       if (this.hasOwnCredentials) {
         // check if identifier is custom or not
-        if (this._hasCustomAccessPolicies || this._isCustomPolicy(identifier)) {
+        if (this._isCustomPolicy(identifier)) {
           const msg = 'Container has one or more custom policies defined. Either remove all custom policies or use another container.'
           logAndThrow(new codes.ERROR_INIT_FAILURE({ messageValues: [msg], sdkDetails: {} }))
         }
@@ -303,13 +304,9 @@ class AzureBlobFiles extends Files {
    * @private
    */
   _isCustomPolicy (identifier) {
-    if (identifier.startsWith('aio-lib-files')) {
-      return false
-    } else {
-      // if its uuidv4 type of identifier then consider it as non custom, this is to support any already created policies by aio-lib-flies
-      const testUUIDv4 = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi
-      return !(testUUIDv4.test(identifier))
-    }
+    // if its uuidv4 type of identifier then consider it as non custom, this is to support any already created policies by aio-lib-flies
+    const testUUIDv4 = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi
+    return !(testUUIDv4.test(identifier))
   }
 
   /* **************************** PRIVATE METHODS TO IMPLEMENT ***************************** */


### PR DESCRIPTION
Fixes [https://github.com/adobe/aio-tvm/issues/46](https://github.com/adobe/aio-tvm/issues/46)
Added check for presence of custom policies in case of BYO credentials.
If custom policies are detected init will throw error reporting the same.
Added policy prefix to easily detect policies created by aio-lib-files

TODO - add and fix existing unit tests

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
