### PR TITLE
use default crypto

### DIFF
--- a/lib/impl/AzureBlobFiles.js
+++ b/lib/impl/AzureBlobFiles.js
@@ -17,7 +17,7 @@ const joi = require('@hapi/joi')
 const stream = require('stream')
 const mime = require('mime-types')
 const fetch = require('node-fetch')
-const Crypto = require('crypto')
+const crypto = require('crypto')
 const { v4: uuidv4 } = require('uuid')
 const xmlJS = require('xml-js')
 const logger = require('@adobe/aio-lib-core-logging')('@adobe/aio-lib-files', { provider: 'debug' })
@@ -268,7 +268,7 @@ class AzureBlobFiles extends Files {
   _signRequest (method, resource, date) {
     const canonicalHeaders = 'x-ms-date:' + date + '\n' + 'x-ms-version:2019-02-02'
     var stringToSign = method + '\n\n\n\n\n\n\n\n\n\n\n\n' + canonicalHeaders + '\n' + resource
-    return Crypto.createHmac('sha256', Buffer.from(this.credentials.storageAccessKey, 'base64')).update(stringToSign, 'utf8').digest('base64')
+    return crypto.createHmac('sha256', Buffer.from(this.credentials.storageAccessKey, 'base64')).update(stringToSign, 'utf8').digest('base64')
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@azure/storage-blob": "^12.3.0",
     "@hapi/joi": "^16.1.7",
     "@types/hapi__joi": "^16.0.1",
-    "crypto": "^1.0.1",
     "fs-extra": "^9.0.0",
     "lodash.clonedeep": "^4.5.0",
     "mime-types": "^2.1.24",


### PR DESCRIPTION


## Description

Installing new projects there is a warning displayed:
```bash
Running npm install for you to install the required dependencies.
npm WARN deprecated crypto@1.0.1: This package is no longer supported. It's now a built-in Node module. 
If you've depended on crypto, you should switch to the one that's built-in.
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
