### PR TITLE
Fix for URL access from outside runtime actions

### DIFF
--- a/lib/impl/AzureBlobFiles.js
+++ b/lib/impl/AzureBlobFiles.js
@@ -115,7 +115,7 @@ class AzureBlobFiles extends Files {
       this.usesSASCreds = true
     } else {
       const azureCreds = new azure.StorageSharedKeyCredential(credentials.storageAccount, credentials.storageAccessKey)
-      const blobServiceClient = new azure.BlobServiceClient(`https://${credentials.storageAccount}.blob.core.windows.net/`, azureCreds)
+      const blobServiceClient = new azure.BlobServiceClient(`https://${credentials.storageAccount}.${AZURE_STORAGE_DOMAIN}/`, azureCreds)
       this.containerClientPrivate = blobServiceClient.getContainerClient(credentials.containerName)
       this.containerClientPublic = blobServiceClient.getContainerClient(credentials.containerName + PUBLIC_CONTAINER_SUFFIX)
       this.usesSASCreds = false
@@ -205,10 +205,17 @@ class AzureBlobFiles extends Files {
     }
 
     if (credentials || !this.hasOwnCredentials) {
+      // this seems like an error, if we get here without credentials this will throw
+      // when we access credentials.sasURLPrivate, should this be an && instead of || ?
       const azureCreds = new azure.AnonymousCredential()
       const pipeline = azure.newPipeline(azureCreds)
-      this.containerClientPrivate = new azure.ContainerClient(credentials.sasURLPrivate, pipeline)
-      this.containerClientPublic = new azure.ContainerClient(credentials.sasURLPublic, pipeline)
+      const privateUrl = new URL(credentials.sasURLPrivate)
+      privateUrl.host = DEFAULT_CDN_STORAGE_HOST
+      const publicUrl = new URL(credentials.sasURLPublic)
+      publicUrl.host = DEFAULT_CDN_STORAGE_HOST
+
+      this.containerClientPrivate = new azure.ContainerClient(privateUrl.toString(), pipeline)
+      this.containerClientPublic = new azure.ContainerClient(publicUrl.toString(), pipeline)
     }
   }
 
@@ -524,23 +531,23 @@ class AzureBlobFiles extends Files {
    * @private
    */
   _getUrl (filePath, urlType = UrlType.external) {
+    // this kindof does the opposite now
+    // ie. azureURL was always an internal url, and we returned a modified version for external
+    // now azureURL is always external, and we return a modified version for internal
     const azureURL = this._propsForPath(filePath).blockBlobClient.url.split('?')[0]
-    if (urlType === UrlType.internal) {
-      return azureURL
-    }
-
     let hostNameToUse = this.defaultHostName
 
-    if (this.hasOwnCredentials) {
-      if (this.credentials.hostName) {
-        hostNameToUse = this.credentials.hostName
-      } else {
-        return azureURL
-      }
+    if (urlType === UrlType.internal) {
+      hostNameToUse = `${this.credentials.storageAccount}.${AZURE_STORAGE_DOMAIN}`
     }
 
-    const index = azureURL.indexOf(AZURE_STORAGE_DOMAIN)
-    return 'https://' + hostNameToUse + azureURL.substring(index + AZURE_STORAGE_DOMAIN.length)
+    if (this.hasOwnCredentials && this.credentials.hostName) {
+      hostNameToUse = this.credentials.hostName
+    }
+    const url = new URL(azureURL)
+    url.protocol = 'https:'
+    url.host = hostNameToUse
+    return url.toString()
   }
 
   /**


### PR DESCRIPTION


## Description

This changes the default url types returned.
internalUrls are of the form <storage-account>.blob.core.windows.net
and urls are using our files cdn firefly.azureedge.net

Some other fixes to make sure we are formatting urls correctly, switched to use the Url class instead of problematic string modification.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
