### PR TITLE
fix: max of 1000 items listed, copied, or deleted for the list, copy, and delete api

### DIFF
--- a/lib/Files.js
+++ b/lib/Files.js
@@ -407,6 +407,8 @@ class Files {
    *
    * Lists files in a remote folder. If called on a file returns the file info if the file exists.
    * If the file or folder does not exist returns an empty array.
+   * 
+   * There is a max limit of 1000 items listed.
    *
    * @param {RemotePathString} [filePath] {@link RemotePathString} if not
    * specified list all files
@@ -441,6 +443,8 @@ class Files {
 
   /**
    * Deletes a remote file or directory
+   *
+   * There is a max limit of 1000 items deleted in a directory.
    *
    * @param {RemotePathString} filePath {@link RemotePathString}
    * @param {object} [options={}] remoteDeleteOptions
@@ -626,6 +630,8 @@ class Files {
    *  4. Local => Local
    *    - not supported
    *
+   * There is a max limit of 1000 items copied.
+   * 
    * @param {RemotePathString} srcPath copy source path to a file or directory. If srcPath
    * points to a local file set `options.localSrc` to true
    * @param {RemotePathString} destPath copy destination path to a file or directory. If


### PR DESCRIPTION
See https://github.com/adobe/aio-lib-files/pull/155
Internally .copy and .delete also use .list

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
